### PR TITLE
Use Docker's multi-stage builds to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,36 @@
+FROM lwieske/java-8:jdk-8u202-slim as build
+
+# Work work work!
+WORKDIR /work
+
+# Base Install
+RUN apk add --no-cache git
+
+# Building Grasscutter Source (with bypass cache https://stackoverflow.com/a/36996107)
+ADD https://api.github.com/repos/Grasscutters/Grasscutter/commits /tmp/bustcache
+RUN git clone -b development https://github.com/Grasscutters/Grasscutter.git && \
+    cd Grasscutter && \
+    # Need utf-8
+    export GRADLE_OPTS="-Dfile.encoding=utf-8"  && \
+    # Run it :)
+    chmod +x gradlew && ./gradlew jar && \
+    # We delete it because it is only needed during building process.
+    rm -R -f Grasscutter-Protos LICENSE README.md build build.gradle gradle gradlew gradlew.bat lib proxy.py proxy_config.py run.cmd settings.gradle src
+
 FROM lwieske/java-8:jdk-8u202-slim
+
+# Install json utilities for config.json
+RUN apk add --no-cache npm && npm install --unsafe-perm -g json
 
 # Sweet Home Alabama :)
 WORKDIR /home
 
-# Base Install
-RUN apk add --no-cache git npm &&\
-    # for config.json stuff
-    npm install --unsafe-perm -g json
+# EXPOSE Web (https) and Game Server
+EXPOSE 443 22102
 
-# Building Grasscutter Source (with bypass cache https://stackoverflow.com/a/36996107)
-ADD https://api.github.com/repos/Grasscutters/Grasscutter/commits /tmp/bustcache
-RUN git clone -b development https://github.com/Grasscutters/Grasscutter.git &&\
-    cd Grasscutter && \
-    # Need utf-8
-    export GRADLE_OPTS="-Dfile.encoding=utf-8"  &&\
-    # Run it :)
-    chmod +x gradlew && ./gradlew jar &&\
-    # We delete it because it is only needed during building process.
-    rm -R -f Grasscutter-Protos LICENSE README.md build build.gradle gradle gradlew gradlew.bat lib proxy.py proxy_config.py run.cmd settings.gradle src
-
-# FOR WEB HTTPS MODE
-EXPOSE 443
-# FOR GAME SERVER
-EXPOSE 22102
-
-# Missing file
-COPY missing/ missing/
+# Copy files
+COPY --from=build /work/Grasscutter ./Grasscutter
+COPY missing ./missing
 
 # Rock
 COPY entrypoint.sh .


### PR DESCRIPTION
Docker images is built up from a series of layers. Each layer represents an instruction in the image’s Dockerfile. Meaning every instructions in the image's Dockerfile will have it's own layer, and will still exists on the final image.

I see that in line 20 on original Dockerfile, you are removing some dirty stuffs from gradle for runtime, that's good, but what you don't know that there is still a leftover in `/root/.gradle`, you could also remove it manually using `rm` but using multi-stage like this is more proper/better or you can say clean

With multi-stage builds, every dirty stuffs while compiling will not go into the final image, so no need to delete `/root/.gradle` or even `/tmp/*`, so with that, this PR will reduce image size from 514MB to 232MB

Old image layers:
![image](https://user-images.githubusercontent.com/32807631/164586111-79c0c9d2-002d-46be-9a9b-1aa7626b7c77.png)

New image layers: 
![image](https://user-images.githubusercontent.com/32807631/164586219-dda005cb-06de-4e7f-ba99-49bfb3aac151.png)

And, on the final layer of new image:
![image](https://user-images.githubusercontent.com/32807631/164587169-d3bef303-a1b7-4b19-874c-0a92db5f99f1.png)
